### PR TITLE
base repository: pyg-team/pytorch_geometric ← compare: KAVYANSHTYAGI:fix/set-transformer-aggregation-index-check

### DIFF
--- a/torch_geometric/nn/aggr/set_transformer.py
+++ b/torch_geometric/nn/aggr/set_transformer.py
@@ -94,6 +94,17 @@ class SetTransformerAggregation(Aggregation):
         max_num_elements: Optional[int] = None,
     ) -> Tensor:
 
+        if dim_size is None:
+            dim_size = int(index.max()) + 1
+
+        if int(index.max()) >= dim_size:
+            raise ValueError(
+                f"SetTransformerAggregation error: index.max() = {int(index.max())}, "
+                f"but dim_size = {dim_size}. This causes an indexing error on GPU. "
+                f"Ensure data.batch is set or dim_size is passed explicitly."
+    )
+
+
         x, mask = self.to_dense_batch(x, index, ptr, dim_size, dim,
                                       max_num_elements=max_num_elements)
 


### PR DESCRIPTION
This PR improves the robustness of `SetTransformerAggregation` by:

- Automatically setting `dim_size = index.max() + 1` if `dim_size` is not provided.
- Raising a clear error if `index.max() >= dim_size` to avoid CUDA crashes during evaluation.

This prevents silent GPU crashes when `data.batch` is missing (e.g., in PPI) and makes debugging much easier. 
Thanks!
